### PR TITLE
Fix `./Configure.pl --prefix=../install`

### DIFF
--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -306,6 +306,7 @@ sub use_backend {
 
 sub active_backends {
     my $self = shift;
+    return () if !$self->{active_backends_order};
     return @{ $self->{active_backends_order} };
 }
 


### PR DESCRIPTION
When calling NQP `./Configure.pl --prefix=../install` I get the following error:
`Can't use an undefined value as an ARRAY reference at ...`
This change fixes that.