### PR TITLE
--perl6-home and --nqp-home support

### DIFF
--- a/doc/Macros.md
+++ b/doc/Macros.md
@@ -61,7 +61,7 @@ A configuration variable is set either from CLI options, or as a result of
 detection process performed by the `Configure.pl` script, or any other source of
 information.
 
-For example, `@libdir@` could either be set with `--libdir` option of
+For example, `@perl6_home@` could either be set with `--perl6-home` option of
 `Configure.pl`, or set to a default value using a value from `@prefix@`
 variable.
 

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -586,11 +586,6 @@ sub configure_refine_vars {
         $config->{prefix} = $default;
     }
     $config->{prefix} = File::Spec->rel2abs( $config->{prefix} );
-
-    unless ( $config->{libdir} ) {
-        $config->{libdir} =
-          File::Spec->catdir( $config->{prefix}, 'share' );
-    }
 }
 
 sub parse_backends {
@@ -637,7 +632,7 @@ sub configure_from_options {
     my $self   = shift;
     my $config = $self->{config};
     for my $opt (
-        qw<prefix libdir perl6-home nqp-home sdkroot sysroot github-user git-protocol
+        qw<prefix perl6-home nqp-home sdkroot sysroot github-user git-protocol
         rakudo-repo nqp-repo moar-repo roast-repo makefile-timing
         relocatable reference>
       )

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -475,6 +475,13 @@ sub configure_relocatability {
         );
     }
 
+    if ( $self->{options}->{relocatable} && ($self->{options}->{'perl6-home'} || $self->{options}->{'nqp-home'} ) ) {
+        $self->sorry( "It's not possible to build a relocatable rakudo and use hard coded perl6-home"
+              . "\nor nqp-home directories. So either don't use the `--relocatable` parameter or don't"
+              . "\nuse the `--perl6-home` and `--nqp-home` parameters."
+        );
+    }
+
     $self->{config}->{relocatable} =
       $self->{options}->{relocatable} ? 'reloc' : 'nonreloc';
 }
@@ -630,7 +637,7 @@ sub configure_from_options {
     my $self   = shift;
     my $config = $self->{config};
     for my $opt (
-        qw<prefix libdir sdkroot sysroot github-user git-protocol
+        qw<prefix libdir perl6-home nqp-home sdkroot sysroot github-user git-protocol
         rakudo-repo nqp-repo moar-repo roast-repo makefile-timing
         relocatable reference>
       )


### PR DESCRIPTION
Process the `perl6-home` and `nqp-home` parameters. Also drop support for `--libdir` which the previous two options should replace. This work supports two other PRs for NQP and Rakudo.