### PR TITLE
[WIP] Provide common ground for all backend makefiles

### DIFF
--- a/doc/Macros.md
+++ b/doc/Macros.md
@@ -493,6 +493,21 @@ For ease of use, the following variables are pre-declared:
 - `$out` – content of this variable will be returned as macro result unless the
   snippet returns something explicitly.
 
+### use_prereqs(text)
+
+_Pre-expanded_
+
+This macro must be used within a Makefile receipe context. It doesn't modify its
+parameter but stores it in the context `prereqs` variable to be used by the
+receipe to build its target.
+
+For example, let's say a fictios macro `receipe` creates a receipe context:
+
+```
+@receipe(@nfp($(GEN_DIR)/foo.nqp)@: @use_prereqs($(FOO_SOURCES))@ @@other_deps@@
+    cat @prereqs@ >$@)@
+```
+
 ### echo(text)
 
 _Pre-expanded_

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -729,7 +729,7 @@ sub make_option {
     state $bool_opt = {
         map { $_ => 1 }
           qw<
-          relocatable no-clean ignore-errors
+          relocatable no-clean ignore-errors silent-build
           >
     };
 

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -738,9 +738,7 @@ sub make_option {
 
     my $opt_str = "";
     if ( $bool_opt->{$opt} ) {
-        if ( $options->{$opt} ) {
-            $opt_str = "--$opt";
-        }
+        $opt_str = "--" . ($options->{$opt} ? '' : 'no-')  . "$opt";
     }
     elsif ( defined $options->{$opt} ) {
         my $opt_value =

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -127,13 +127,15 @@ sub init {
         jvm  => 'j',
         js   => 'js',
     };
+
     # Precompiled files extensions
     $self->{backend_ext} = {
         moar => 'moarvm',
         jvm  => 'jar',
         js   => 'js',
     };
-    # Value of nqp --target 
+
+    # Value of nqp --target
     $self->{backend_target} = {
         moar => 'mbc',
         jvm  => 'jar',
@@ -142,9 +144,10 @@ sub init {
     $self->{backends_order} = [qw<moar jvm js>];
     $self->{options}        = {
         'silent-build' => 1,
+        'clean'        => 1,
     };
-    $self->{contexts}       = [];
-    $self->{repo_maps}      = {
+    $self->{contexts}  = [];
+    $self->{repo_maps} = {
         rakudo => [qw<rakudo rakudo>],
         nqp    => [qw<perl6 nqp>],
         moar   => [qw<MoarVM MoarVM>],
@@ -241,7 +244,7 @@ sub make_cmd {
         if (
             -x "$prefix\\bin\\nqp-m.exe"
             && ( $_ =
-                `"$prefix\\bin\\nqp-m.exe" -e "print(nqp::backendconfig()<make>)"`
+`"$prefix\\bin\\nqp-m.exe" -e "print(nqp::backendconfig()<make>)"`
             )
           )
         {
@@ -250,7 +253,7 @@ sub make_cmd {
         elsif (
             -x "$prefix\\bin\\nqp-m.bat"
             && ( $_ =
-                `"$prefix\\bin\\nqp-m.bat" -e "print(nqp::backendconfig()<make>)"`
+`"$prefix\\bin\\nqp-m.bat" -e "print(nqp::backendconfig()<make>)"`
             )
           )
         {
@@ -502,22 +505,22 @@ sub configure_commands {
         $ok = run( command => [ $config->{make}, q</?> ], buffer => \$buf );
     }
     if ( $buf =~ /^GNU Make/s ) {
-        $config->{make_family} = 'gnu';
+        $config->{make_family}       = 'gnu';
         $config->{make_first_prereq} = '$<';
-        $config->{make_all_prereq} = '$^';
-        $config->{make_pp_pfx} = ''; # make preprocessor directive prefix
+        $config->{make_all_prereq}   = '$^';
+        $config->{make_pp_pfx} = '';    # make preprocessor directive prefix
     }
     elsif ( $buf =~ /Microsoft \(R\) Program Maintenance Utility/s ) {
-        $config->{make_family} = 'nmake';
+        $config->{make_family}       = 'nmake';
         $config->{make_first_prereq} = '%s';
-        $config->{make_all_prereq} = '$**';
-        $config->{make_pp_pfx} = '!';
+        $config->{make_all_prereq}   = '$**';
+        $config->{make_pp_pfx}       = '!';
     }
     elsif ( $self->is_bsd && $config->{make} =~ /\bmake$/ ) {
-        $config->{make_family} = 'bsd';
+        $config->{make_family}       = 'bsd';
         $config->{make_first_prereq} = '${>:[1]}';
-        $config->{make_all_prereq} = '$>';
-        $config->{make_pp_pfx} = '.';
+        $config->{make_all_prereq}   = '$>';
+        $config->{make_pp_pfx}       = '.';
     }
     unless ( defined $config->{make_family} ) {
         $self->sorry(
@@ -759,7 +762,7 @@ sub ignorable_opts {
     my $self = shift;
     my $opt  = shift;
     return qw<gen-moar gen-nqp help make-install expand out
-      prefix backends set-var silent-build>;
+      prefix backends set-var silent-build clean>;
 }
 
 # Generate Configure.pl options from the data we have so far.
@@ -778,7 +781,8 @@ sub opts_for_configure {
         push @subopts, $opt_str if $opt_str;
     }
     push @subopts, "--backends=" . join( ",", $self->active_backends );
-    push @subopts, "--prefix=" . $self->shell_quote_filename($self->cfg('prefix'));
+    push @subopts,
+      "--prefix=" . $self->shell_quote_filename( $self->cfg('prefix') );
     push @subopts, "--silent-build" if $self->option('silent-build');
     return wantarray ? @subopts : join( " ", @subopts );
 }
@@ -908,7 +912,7 @@ sub find_filepath {
     my $ctx_subdir = $self->cfg('ctx_subdir');
     push @subdirs, $ctx_subdir if $ctx_subdir;
 
-    my $where = $params{where} || 'templates';
+    my $where     = $params{where} || 'templates';
     my $where_dir = $self->cfg( "${where}_dir", strict => 1 );
     my @suffixes;
     push @suffixes, $params{suffix}        if $params{suffix};
@@ -1273,12 +1277,11 @@ sub set {
         my $ctx;
         if ( $prop eq -1 ) {
             $ctx = $self->{contexts}[-1];
-        } else {
+        }
+        else {
             unless ( $ctx = $self->in_ctx($prop) ) {
-                $self->sorry(
-                    "No context '$prop' found"
-                    . " while attemtped to set variable $key"
-                );
+                $self->sorry( "No context '$prop' found"
+                      . " while attemtped to set variable $key" );
             }
         }
         $ctx->{configs}[-1]{$key} = $val;
@@ -1313,9 +1316,9 @@ sub in_ctx {
     my ( $prop, $val ) = @_;
 
     for my $ctx ( $self->contexts ) {
-        return $ctx 
-            if exists $ctx->{$prop} 
-               && ( !defined($val) || ($ctx->{$prop} eq $val));
+        return $ctx
+          if exists $ctx->{$prop}
+          && ( !defined($val) || ( $ctx->{$prop} eq $val ) );
     }
 
     return 0;
@@ -1482,7 +1485,7 @@ sub cmp_rev {
 
 sub read_config_from_command {
     my $command = shift;
-    my %config     = ();
+    my %config  = ();
     local $_;
     no warnings;
     if ( open my $CONFIG, '-|', $command ) {

--- a/lib/NQP/Macros.pm
+++ b/lib/NQP/Macros.pm
@@ -471,6 +471,13 @@ sub in_receipe_context {
     );
 }
 
+# Set a config variable in receipe context.
+sub set_in_receipe {
+    my $self = shift;
+    my ($var, $val) = @_;
+    $self->cfg->set($var, $val, in_ctx => '.make_receipe');
+}
+
 sub backends_iterate {
     my $self = shift;
     my $cfg  = $self->{config_obj};

--- a/t/10-config.t
+++ b/t/10-config.t
@@ -41,6 +41,7 @@ subtest "Contexts" => sub {
                             level     => $l,
                         }
                     ],
+                    "level$l" => $l,
                 }
               );
         }
@@ -49,6 +50,16 @@ subtest "Contexts" => sub {
         is $config->cfg('level'), 10, "last added context is dominant";
         for my $l ( 1 .. 10 ) {
             is $config->cfg("level$l"), "ok", "level $l context variable ok";
+        }
+
+        for my $l ( 1..10 ) {
+            is $config->cfg('inserted'), undef, "variable isn't set yet";
+            $config->set('inserted', 'value', in_ctx => "level$l");
+            is $config->cfg('inserted'), 'value', "variable has been inserted into a context";
+            my $ctx = $config->in_ctx("level$l");
+            ok exists $ctx->{configs}[-1]{inserted}, "variable has been inserted into correct context";
+            delete $ctx->{configs}[-1]{inserted};
+            is $config->cfg('inserted'), undef, "variable has been removed";
         }
 
         pop @ctx_sc;


### PR DESCRIPTION
Provide better support for cross-backend templates.

Most crucial changes are:

- introduced term `receipe macros`: a class of macros responsible for generating rules.
- `use_prereqs` macro for replacing *first target* Makefile variables. Stores its content in `@prereqs@` variable in enclosing receipe macro context.
- the above required `NQP::Config::set` method to support context name in `in_ctx` named parameter.

Related to perl6/nqp#580 and rakudo/rakudo#3194