### PR TITLE
Make sure we don't strip `./` relative path markers from paths

### DIFF
--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -1354,11 +1354,9 @@ sub nfp {
     my $self = shift;
     my ( $vol, $dirs, $file ) = File::Spec->splitpath(shift);
     my %params   = @_;
-    my $filename = File::Spec->canonpath(
-        File::Spec->catpath(
-            $vol,
-            File::Spec->catdir( File::Spec::Unix->splitdir($dirs) ), $file
-        )
+    my $filename = File::Spec->catpath(
+        $vol,
+        File::Spec->catdir( File::Spec::Unix->splitdir($dirs) ), $file
     );
     $filename = $self->shell_quote_filename($filename) if $params{quote};
     return $filename;


### PR DESCRIPTION
`canonpath()` is a nice thing to do to paths to make them more pleasing
for the eye. But it also strips leading `./` which turns relative
executables into ones resolved via PATH. That's plainly wrong. So go
for less pretty but more correct.