### PR TITLE
Move to --rakudo-home replacing --perl6-home

### DIFF
--- a/doc/Macros.md
+++ b/doc/Macros.md
@@ -61,7 +61,7 @@ A configuration variable is set either from CLI options, or as a result of
 detection process performed by the `Configure.pl` script, or any other source of
 information.
 
-For example, `@perl6_home@` could either be set with `--perl6-home` option of
+For example, `@rakudo_home@` could either be set with `--rakudo-home` option of
 `Configure.pl`, or set to a default value using a value from `@prefix@`
 variable.
 

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -482,12 +482,12 @@ sub configure_relocatability {
 
     if (
         $self->{options}->{relocatable}
-        && (   $self->{options}->{'perl6-home'}
+        && (   $self->{options}->{'rakudo-home'}
             || $self->{options}->{'nqp-home'} )
       )
     {
         $self->sorry(
-"It's not possible to build a relocatable rakudo and use hard coded perl6-home"
+"It's not possible to build a relocatable rakudo and use hard coded rakudo-home"
               . "\nor nqp-home directories. So either don't use the `--relocatable` parameter or don't"
               . "\nuse the `--perl6-home`, `--rakudo-home`, and `--nqp-home` parameters."
         );
@@ -664,7 +664,7 @@ sub configure_from_options {
     my $self   = shift;
     my $config = $self->{config};
     for my $opt (
-        qw<prefix perl6-home nqp-home sdkroot sysroot github-user git-protocol
+        qw<prefix rakudo-home nqp-home sdkroot sysroot github-user git-protocol
         rakudo-repo nqp-repo moar-repo roast-repo makefile-timing
         relocatable reference>
       )


### PR DESCRIPTION
Backwards compatibility is guaranteed by Rakudos Configure.pl mapping
--perl6-home to --rakudo-home.