### PR TITLE
Use the 'Microsoft' keyword to detect nmake.

### DIFF
--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -522,7 +522,7 @@ sub configure_commands {
         $config->{make_all_prereq}   = '$^';
         $config->{make_pp_pfx} = '';    # make preprocessor directive prefix
     }
-    elsif ( $buf =~ /Microsoft \(R\) Program Maintenance Utility/s ) {
+    elsif ( $buf =~ /Microsoft/s ) {
         $config->{make_family}       = 'nmake';
         $config->{make_first_prereq} = '%s';
         $config->{make_all_prereq}   = '$**';


### PR DESCRIPTION
Since the text after 'Microsoft' might vary in different languages, this fix enables users to build projects that use nqp-configure with a localized nmake.

Fixes https://github.com/Raku/nqp-configure/issues/20.
Fixes https://github.com/rakudo/rakudo/issues/3697.
Fixes https://github.com/Raku/nqp/issues/634.
