### PR TITLE
Quote command line parameters (except for Windows)

### DIFF
--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -83,9 +83,9 @@ my %platform_vars = (
         windows => qq<\n>,
         default => qq<#!/bin/sh\n>,
     },
-    sh_allparams => {    # All command line params
+    sh_allparams => {    # All command line params, quoted if necessary
         windows => q<%*>,
-        default => q<$@>,
+        default => q<"$@">,
     },
 );
 


### PR DESCRIPTION
This compensates for https://github.com/Raku/nqp/commit/1517cf77db
and unbreaks nqp-j on non-Windows systems.
Fixes https://github.com/Raku/nqp/issues/644