### PR TITLE
Add `sq_escape()` macro

### DIFF
--- a/doc/Macros.md
+++ b/doc/Macros.md
@@ -174,6 +174,15 @@ _Pre-expanded_
 
 Escapes newlines in the parameter with `\`.
 
+### `c_escape(text)`
+
+Escapes a string for use in `C` source code.
+
+### `sq_escape(text)`
+
+Escaping single quotes and backslashes.
+Can e.g. be used in a Perl '' string.
+
 ### sp_unescape(text)
 
 Very simple unescaping. Replaces all `\<char>` sequences with `<char>`.

--- a/doc/NQP-Config.md
+++ b/doc/NQP-Config.md
@@ -520,6 +520,11 @@ Returns normalized file name.
 
 Escapes a string for use in `C` source code.
 
+### `sq_escape_string($string)`
+
+Escapes a string for use in single quoted delimiters.
+E.g. a Perl '' string.
+
 # ROUTINES
 
 ### `slash`

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -1425,6 +1425,14 @@ sub c_escape_string {
     return $str;
 }
 
+sub sq_escape_string {
+    my $self = shift;
+    my $str  = shift;
+    $str =~ s{\\}{\\\\}sg;
+    $str =~ s{'}{\\'}sg;
+    return $str;
+}
+
 #########################################################
 ### Non-method subs
 #########################################################

--- a/lib/NQP/Macros.pm
+++ b/lib/NQP/Macros.pm
@@ -91,9 +91,9 @@ my %preexpand = map { $_ => 1 } qw<
   include include_capture nfp nfpl nfpq nfplq q
   insert insert_capture insert_filelist
   expand template ctx_template script ctx_script
-  sp_escape nl_escape c_escape fixup uc lc abs2rel
-  shquot mkquot chomp if bpv bpm bsv bsm echo
-  use_prereqs
+  sp_escape nl_escape c_escape sq_escape fixup uc
+  lc abs2rel shquot mkquot chomp if bpv bpm bsv
+  bsm echo use_prereqs
 >;
 
 my %receipe_macro;
@@ -705,8 +705,19 @@ sub _m_c_escape {
     return $str;
 }
 
+# sq_escape(text)
+# Escaping single quotes and backslashes.
+# Can e.g. be used in a Perl '' string.
+sub _m_sq_escape {
+    my $self = shift;
+    my $str  = shift;
+    $str =~ s{\\}{\\\\}sg;
+    $str =~ s{'}{\\'}sg;
+    return $str;
+}
+
 # sp_unescape(a\ st\ring)
-# Simlpe unescaping horizontal whitespaces from backslashes.
+# Simple unescaping horizontal whitespaces from backslashes.
 sub _m_sp_unescape {
     my $self = shift;
     my $str  = shift;


### PR DESCRIPTION
Helpful when filling in Perl script templates. This is required by
rakudo/rakudo#3918.