### PR TITLE
Consider /dragonfly/ a BSD as well

### DIFF
--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -848,7 +848,7 @@ sub is_solaris {
 }
 
 sub is_bsd {
-    state $bsd = $^O =~ /bsd/;
+    state $bsd = $^O =~ /bsd|dragonfly/;
     return $bsd;
 }
 


### PR DESCRIPTION
In Perl, `$^O` is `dragonfly` when running DragonflyBSD. As this doesn't
match the `/bsd/` that is done to determine bsd-ness, this screws up the
`make` check, which results in NQP and Rakudo failing to build on
DragonflyBSD.