### PR TITLE
 Config.pm: Windows: Ensure x64 architecture

### DIFF
--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -259,7 +259,7 @@ sub make_cmd {
                           . "+, but got "
                           . $actual_version );
                 }
-                if ( $cl_arch ne "x64 ) {
+                if ( $cl_arch ne "x64" ) {
                     $self->sorry( "Rakudo compiles currently only on "
                           . "x64 architectures, but we are on "
                           . $cl_arch );

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -247,15 +247,22 @@ sub make_cmd {
         my $has_gcc   = 0 == system('gcc --version >NUL 2>&1');
         if ($has_cl) {
             if ( $cl_report =~
-                /Microsoft\s.*\sCompiler\s+Version\s+(\d+(?:\.\d+)+)/i )
+                /Microsoft\s.*\sCompiler\s+Version\s+(\d+(?:\.\d+)+)\s+for\s+(x\d+)/i )
             {
                 my $actual_version = $1;
+		my $cl_arch        = $2;
                 my $expect_version = "19.0";
+		
                 if ( version->parse($actual_version) < $expect_version ) {
                     $self->sorry( "Expected Microsoft Compiler version "
                           . $expect_version
                           . "+, but got "
                           . $actual_version );
+                }
+                if ( $cl_arch ne "x64 ) {
+                    $self->sorry( "Rakudo compiles currently only on "
+                          . "x64 architectures, but we are on "
+                          . $cl_arch );
                 }
             }
         }

--- a/lib/NQP/Config.pm
+++ b/lib/NQP/Config.pm
@@ -247,7 +247,7 @@ sub make_cmd {
         my $has_gcc   = 0 == system('gcc --version >NUL 2>&1');
         if ($has_cl) {
             if ( $cl_report =~
-                /Microsoft\s.*\sCompiler\s+Version\s+(\d+(?:\.\d+)+)\s+for\s+(x\d+)/i )
+                /Microsoft\s.*\sCompiler\s+Version\s+(\d+(?:\.\d+)+)\s+for\s+(\D+\d+)/i )
             {
                 my $actual_version = $1;
 		my $cl_arch        = $2;
@@ -259,9 +259,9 @@ sub make_cmd {
                           . "+, but got "
                           . $actual_version );
                 }
-                if ( $cl_arch ne "x64" ) {
-                    $self->sorry( "Rakudo compiles currently only on "
-                          . "x64 architectures, but we are on "
+                if ( $cl_arch !~ m/\D+64$/ ) {
+                    $self->sorry( "On Microsoft Windows, Rakudo compiles currently only on "
+                          . "64bit architectures, but we are on "
                           . $cl_arch );
                 }
             }


### PR DESCRIPTION
As far as I know, Rakudo is not building under 32bit Windows.
If so, let's check and assure we use the MSVC 64bit cl.exe for a desired build run.

See also https://github.com/MoarVM/MoarVM/issues/1789#issuecomment-2028464981
