### PR TITLE
Allow config keys with double colon in @if()@

### DIFF
--- a/lib/NQP/Macros.pm
+++ b/lib/NQP/Macros.pm
@@ -1020,7 +1020,7 @@ sub _m_if {
         # preserving \t in makefiles.
         $text = ( $ws eq ' ' ? '' : $ws ) . $+{text};
         my $matches = 0;
-        if ( $cond =~ /^(?<var>\w(?:\w|:\w)*)(?:(?<op>[=\!]=)(?<val>.*))?$/ ) {
+        if ( $cond =~ /^(?<var>\w(?:\w|:\w|::\w)*)(?:(?<op>[=\!]=)(?<val>.*))?$/ ) {
             if ( $+{op} ) {
                 my $val      = $+{val};
                 my $var      = $+{var};


### PR DESCRIPTION
Needed because I want to check for `moar::cc`.